### PR TITLE
Fixes for PHP warning and broken selected option

### DIFF
--- a/acf-role-selector-field/trunk/acf-role_selector-v5.php
+++ b/acf-role-selector-field/trunk/acf-role_selector-v5.php
@@ -146,7 +146,11 @@ class acf_field_role_selector extends acf_field {
 			<select name='<?php echo $field['name'] ?>[]' <?php echo $multiple ?>>
 				<?php
 					foreach( $roles as $role => $data ) :
-					$selected = ( !empty( $field['value'] ) && in_array( $role, $field['value'] ) ) ? 'selected="selected"' : '';
+					if ( 'object' === $field['return_value'] ) {
+						$selected = ( !empty( $field['value'] ) && in_array( $role, wp_list_pluck( $field['value'], 'name' ) ) ) ? 'selected="selected"' : '';
+					} else {
+						$selected = ( !empty( $field['value'] ) && in_array( $role, $field['value'] ) ) ? 'selected="selected"' : '';
+					}
 				?>
 					<option <?php echo $selected ?> value='<?php echo $role ?>'><?php echo $data['name'] ?></option>
 				<?php endforeach; ?>

--- a/acf-role-selector-field/trunk/acf-role_selector-v5.php
+++ b/acf-role-selector-field/trunk/acf-role_selector-v5.php
@@ -209,7 +209,7 @@ class acf_field_role_selector extends acf_field {
 	 */
 	function load_value($value, $post_id, $field) {
 
-		if( $field['return_value'] == 'object' )
+		if( $field['return_value'] == 'object' && is_array( $value ) )
 		{
 			foreach( $value as $key => $name ) {
 				$value[$key] = get_role( $name );


### PR DESCRIPTION
First off, thanks for the plugin!

A couple of fixes:

1. Loaded value type wasn't being checked, so an empty value passed in to load_value() was throwing a warning when trying to foreach() on it.

2. When the return type was set to Role Object, the selected option wasn't being set correctly.

Regards,

Matt.